### PR TITLE
Added an 'else' when adding to existingDomains

### DIFF
--- a/enable-screen-capturing/index.js
+++ b/enable-screen-capturing/index.js
@@ -20,10 +20,7 @@ function addMyOwnDomains() {
     arrayOfMyOwnDomains.forEach(function(domain) {
         if (existingDomains.indexOf(domain) === -1) {
             existingDomains.push(domain);
-        }
-
-        // else { }
-        if (existingDomains.indexOf(domain) !== -1) {
+        } else if (existingDomains.indexOf(domain) !== -1) {
             // Seems domain is already in the list.
             // Keep it when this addon is uninstalled.
             listOfSimilarAlreadyAllowedDomains.push(domain);


### PR DESCRIPTION
Added an 'else' inside the forEach loop of addMyOwnDomains(). Without it, every value in arrayOfMyOwnDomains will always be added to listOfSimilarAlreadyAllowedDomains. This prevents removeMyDomainOnUnInstall() from actually removing any domains.