### PR TITLE
Use document.defaultView instead of window

### DIFF
--- a/enable-screen-capturing/content-script.js
+++ b/enable-screen-capturing/content-script.js
@@ -7,7 +7,7 @@
 window.addEventListener("message", function(event) {
     // do NOT allow external domains
     // via: https://github.com/muaz-khan/Firefox-Extensions/issues/11
-    if (event.source !== window) return;
+    if (event.source !== document.defaultView) return;
 
     var addonMessage = event.data;
 


### PR DESCRIPTION
In content scripts of the Add-on SDK, the window object is not the true DOMWindow. Use `document.defaultView` to get a reference to the true DOMWindow for comparison `with event.source`. Without this patch, the condition is always true and the "message" handler would always return early.